### PR TITLE
Implement removal of orphan nodes

### DIFF
--- a/bulk_test.go
+++ b/bulk_test.go
@@ -22,8 +22,8 @@ func TestSparseMerkleTree(t *testing.T) {
 
 // Test all tree operations in bulk, with specified ratio probabilities of insert, update and delete.
 func bulkOperations(t *testing.T, operations int, insert int, update int, delete int) {
-	sm := NewSimpleMap()
-	smt := NewSparseMerkleTree(sm, sha256.New())
+	smn, smv := NewSimpleMap(), NewSimpleMap()
+	smt := NewSparseMerkleTree(smn, smv, sha256.New())
 
 	max := insert + update + delete
 	kv := make(map[string]string)

--- a/deepsubtree.go
+++ b/deepsubtree.go
@@ -33,7 +33,7 @@ func (dsmst *DeepSparseMerkleSubTree) AddBranch(proof SparseMerkleProof, key []b
 	}
 
 	if valueHash != nil {
-		if err := dsmst.values.Set(dsmst.SparseMerkleTree.th.path(key), value); err != nil {
+		if err := dsmst.values.Set(dsmst.th.path(key), value); err != nil {
 			return err
 		}
 	}

--- a/deepsubtree.go
+++ b/deepsubtree.go
@@ -33,7 +33,7 @@ func (dsmst *DeepSparseMerkleSubTree) AddBranch(proof SparseMerkleProof, key []b
 	}
 
 	if valueHash != nil {
-		if err := dsmst.values.Set(valueKey(key, valueHash), value); err != nil {
+		if err := dsmst.values.Set(dsmst.SparseMerkleTree.th.path(key), value); err != nil {
 			return err
 		}
 	}

--- a/deepsubtree.go
+++ b/deepsubtree.go
@@ -1,6 +1,7 @@
 package smt
 
 import (
+	"bytes"
 	"errors"
 	"hash"
 )
@@ -27,12 +28,12 @@ func NewDeepSparseMerkleSubTree(nodes, values MapStore, hasher hash.Hash, root [
 // If the leaf may be updated (e.g. during a state transition fraud proof),
 // an updatable proof should be used. See SparseMerkleTree.ProveUpdatable.
 func (dsmst *DeepSparseMerkleSubTree) AddBranch(proof SparseMerkleProof, key []byte, value []byte) error {
-	result, updates, valueHash := verifyProofWithUpdates(proof, dsmst.Root(), key, value, dsmst.th.hasher)
+	result, updates := verifyProofWithUpdates(proof, dsmst.Root(), key, value, dsmst.th.hasher)
 	if !result {
 		return ErrBadProof
 	}
 
-	if valueHash != nil {
+	if !bytes.Equal(value, defaultValue) { // Membership proof.
 		if err := dsmst.values.Set(dsmst.th.path(key), value); err != nil {
 			return err
 		}

--- a/deepsubtree_test.go
+++ b/deepsubtree_test.go
@@ -16,7 +16,7 @@ func TestDeepSparseMerkleSubTreeBasic(t *testing.T) {
 	smt.Update([]byte("testKey4"), []byte("testValue4"))
 	smt.Update([]byte("testKey6"), []byte("testValue6"))
 
-	var originalRoot []byte
+	originalRoot := make([]byte, len(smt.Root()))
 	copy(originalRoot, smt.Root())
 
 	proof1, _ := smt.ProveUpdatable([]byte("testKey1"))

--- a/deepsubtree_test.go
+++ b/deepsubtree_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestDeepSparseMerkleSubTreeBasic(t *testing.T) {
-	smt := NewSparseMerkleTree(NewSimpleMap(), sha256.New())
+	smt := NewSparseMerkleTree(NewSimpleMap(), NewSimpleMap(), sha256.New())
 
 	smt.Update([]byte("testKey1"), []byte("testValue1"))
 	smt.Update([]byte("testKey2"), []byte("testValue2"))
@@ -23,7 +23,7 @@ func TestDeepSparseMerkleSubTreeBasic(t *testing.T) {
 	proof2, _ := smt.ProveUpdatable([]byte("testKey2"))
 	proof5, _ := smt.ProveUpdatable([]byte("testKey5"))
 
-	dsmst := NewDeepSparseMerkleSubTree(NewSimpleMap(), sha256.New(), smt.Root())
+	dsmst := NewDeepSparseMerkleSubTree(NewSimpleMap(), NewSimpleMap(), sha256.New(), smt.Root())
 	err := dsmst.AddBranch(proof1, []byte("testKey1"), []byte("testValue1"))
 	if err != nil {
 		t.Errorf("returned error when adding branch to deep subtree: %v", err)
@@ -39,21 +39,21 @@ func TestDeepSparseMerkleSubTreeBasic(t *testing.T) {
 
 	value, err := dsmst.Get([]byte("testKey1"))
 	if err != nil {
-		t.Error("returned error when getting value in deep subtree")
+		t.Errorf("returned error when getting value in deep subtree: %v", err)
 	}
 	if !bytes.Equal(value, []byte("testValue1")) {
 		t.Error("did not get correct value in deep subtree")
 	}
 	value, err = dsmst.Get([]byte("testKey2"))
 	if err != nil {
-		t.Error("returned error when getting value in deep subtree")
+		t.Errorf("returned error when getting value in deep subtree: %v", err)
 	}
 	if !bytes.Equal(value, []byte("testValue2")) {
 		t.Error("did not get correct value in deep subtree")
 	}
 	value, err = dsmst.Get([]byte("testKey5"))
 	if err != nil {
-		t.Error("returned error when getting value in deep subtree")
+		t.Errorf("returned error when getting value in deep subtree: %v", err)
 	}
 	if !bytes.Equal(value, defaultValue) {
 		t.Error("did not get correct value in deep subtree")
@@ -120,7 +120,7 @@ func TestDeepSparseMerkleSubTreeBasic(t *testing.T) {
 }
 
 func TestDeepSparseMerkleSubTreeBadInput(t *testing.T) {
-	smt := NewSparseMerkleTree(NewSimpleMap(), sha256.New())
+	smt := NewSparseMerkleTree(NewSimpleMap(), NewSimpleMap(), sha256.New())
 
 	smt.Update([]byte("testKey1"), []byte("testValue1"))
 	smt.Update([]byte("testKey2"), []byte("testValue2"))
@@ -130,7 +130,7 @@ func TestDeepSparseMerkleSubTreeBadInput(t *testing.T) {
 	badProof, _ := smt.Prove([]byte("testKey1"))
 	badProof.SideNodes[0][0] = byte(0)
 
-	dsmst := NewDeepSparseMerkleSubTree(NewSimpleMap(), sha256.New(), smt.Root())
+	dsmst := NewDeepSparseMerkleSubTree(NewSimpleMap(), NewSimpleMap(), sha256.New(), smt.Root())
 	err := dsmst.AddBranch(badProof, []byte("testKey1"), []byte("testValue1"))
 	if !errors.Is(err, ErrBadProof) {
 		t.Error("did not return ErrBadProof for bad proof input")

--- a/options.go
+++ b/options.go
@@ -2,10 +2,3 @@ package smt
 
 // Option is a function that configures SMT.
 type Option func(*SparseMerkleTree)
-
-// AutoRemoveOrphans option configures SMT to automatically remove orphaned nodes during Update/Delete operation.
-func AutoRemoveOrphans() Option {
-	return func(smt *SparseMerkleTree) {
-		smt.prune = true
-	}
-}

--- a/proofs_test.go
+++ b/proofs_test.go
@@ -10,15 +10,15 @@ import (
 
 // Test base case Merkle proof operations.
 func TestProofsBasic(t *testing.T) {
-	var sm *SimpleMap
+	var smn, smv *SimpleMap
 	var smt *SparseMerkleTree
 	var proof SparseMerkleProof
 	var result bool
 	var root []byte
 	var err error
 
-	sm = NewSimpleMap()
-	smt = NewSparseMerkleTree(sm, sha256.New())
+	smn, smv = NewSimpleMap(), NewSimpleMap()
+	smt = NewSparseMerkleTree(smn, smv, sha256.New())
 
 	// Generate and verify a proof on an empty key.
 	proof, err = smt.Prove([]byte("testKey3"))
@@ -123,8 +123,8 @@ func TestProofsBasic(t *testing.T) {
 
 // Test sanity check cases for non-compact proofs.
 func TestProofsSanityCheck(t *testing.T) {
-	sm := NewSimpleMap()
-	smt := NewSparseMerkleTree(sm, sha256.New())
+	smn, smv := NewSimpleMap(), NewSimpleMap()
+	smt := NewSparseMerkleTree(smn, smv, sha256.New())
 	th := &smt.th
 
 	smt.Update([]byte("testKey1"), []byte("testValue1"))
@@ -199,8 +199,8 @@ func TestProofsSanityCheck(t *testing.T) {
 
 // Test sanity check cases for compact proofs.
 func TestCompactProofsSanityCheck(t *testing.T) {
-	sm := NewSimpleMap()
-	smt := NewSparseMerkleTree(sm, sha256.New())
+	smn, smv := NewSimpleMap(), NewSimpleMap()
+	smt := NewSparseMerkleTree(smn, smv, sha256.New())
 	th := &smt.th
 
 	smt.Update([]byte("testKey1"), []byte("testValue1"))

--- a/smt_test.go
+++ b/smt_test.go
@@ -99,71 +99,13 @@ func TestSparseMerkleTreeUpdateBasic(t *testing.T) {
 		t.Error("did not get correct value when getting non-empty key")
 	}
 
-	// Test that updating a key still allows old values to be accessed from old roots.
-	root := smt.Root()
-	smt.Update([]byte("testKey"), []byte("testValue3"))
-	value, err = smt.GetForRoot([]byte("testKey"), root)
-	if err != nil {
-		t.Errorf("returned error when getting non-empty key: %v", err)
-	}
-	if !bytes.Equal([]byte("testValue2"), value) {
-		t.Error("did not get correct value when getting non-empty key")
-	}
-
-	// Test that it is possible to successfully update a key in an older root.
-	root, err = smt.UpdateForRoot([]byte("testKey3"), []byte("testValue4"), root)
-	if err != nil {
-		t.Errorf("unable to update key: %v", err)
-	}
-	value, err = smt.GetForRoot([]byte("testKey3"), root)
-	if err != nil {
-		t.Errorf("returned error when getting non-empty key: %v", err)
-	}
-	if !bytes.Equal([]byte("testValue4"), value) {
-		t.Error("did not get correct value when getting non-empty key")
-	}
-	value, err = smt.GetForRoot([]byte("testKey"), root)
-	if err != nil {
-		t.Errorf("returned error when getting non-empty key: %v", err)
-	}
-	if !bytes.Equal([]byte("testValue2"), value) {
-		t.Error("did not get correct value when getting non-empty key")
-	}
-	has, err = smt.HasForRoot([]byte("testKey"), root)
-	if err != nil {
-		t.Errorf("returned error when checking presence of non-empty key: %v", err)
-	}
-	if !has {
-		t.Error("did not get 'false' when checking presence of non-empty key")
-	}
-
-	// Test that it is possible to delete key in an older root.
-	root, err = smt.DeleteForRoot([]byte("testKey3"), root)
-	if err != nil {
-		t.Errorf("unable to delete key: %v", err)
-	}
-	value, err = smt.GetForRoot([]byte("testKey3"), root)
-	if err != nil {
-		t.Errorf("returned error when getting empty key: %v", err)
-	}
-	if !bytes.Equal(defaultValue, value) {
-		t.Error("did not get correct value when getting empty key")
-	}
-	has, err = smt.HasForRoot([]byte("testKey3"), root)
-	if err != nil {
-		t.Errorf("returned error when checking presence of empty key: %v", err)
-	}
-	if has {
-		t.Error("did not get 'false' when checking presence of empty key")
-	}
-
 	// Test that a tree can be imported from a MapStore.
 	smt2 := ImportSparseMerkleTree(smn, smv, sha256.New(), smt.Root())
 	value, err = smt2.Get([]byte("testKey"))
 	if err != nil {
 		t.Error("returned error when getting non-empty key")
 	}
-	if !bytes.Equal([]byte("testValue3"), value) {
+	if !bytes.Equal([]byte("testValue2"), value) {
 		t.Error("did not get correct value when getting non-empty key")
 	}
 }
@@ -535,7 +477,7 @@ func TestOrphanRemoval(t *testing.T) {
 
 	setup := func() {
 		smn, smv = NewSimpleMap(), NewSimpleMap()
-		smt = NewSparseMerkleTree(smn, smv, sha256.New(), AutoRemoveOrphans())
+		smt = NewSparseMerkleTree(smn, smv, sha256.New())
 		_, err = smt.Update([]byte("testKey"), []byte("testValue"))
 		if err != nil {
 			t.Errorf("returned error when updating empty key: %v", err)

--- a/smt_test.go
+++ b/smt_test.go
@@ -65,8 +65,8 @@ func TestSparseMerkleTreeUpdateBasic(t *testing.T) {
 		t.Error("did not get correct value when getting non-empty key")
 	}
 
-	// Test updating a second empty key where the path for both keys start with
-	// different bits (when using SHA256).
+	// Test updating a second empty key where the path for both keys share the
+	// first 2 bits (when using SHA256).
 	_, err = smt.Update([]byte("foo"), []byte("testValue"))
 	if err != nil {
 		t.Errorf("returned error when updating empty second key: %v", err)
@@ -404,8 +404,8 @@ func TestSparseMerkleTreeDeleteBasic(t *testing.T) {
 		t.Error("tree root is not as expected after deleting second key")
 	}
 
-	// Test inserting and deleting a different second key, when the the first
-	// bits of the path for the two keys in the tree are different (when using SHA256).
+	// Test inserting and deleting a different second key, when the the first 2
+	// bits of the path for the two keys in the tree are the same (when using SHA256).
 	_, err = smt.Update([]byte("foo"), []byte("testValue"))
 	if err != nil {
 		t.Errorf("unable to update key: %v", err)

--- a/treehasher.go
+++ b/treehasher.go
@@ -20,8 +20,10 @@ func newTreeHasher(hasher hash.Hash) *treeHasher {
 	return &th
 }
 
-func (th *treeHasher) digest(data []byte) []byte {
-	th.hasher.Write(data)
+func (th *treeHasher) digest(data ...[]byte) []byte {
+	for _, item := range data {
+		th.hasher.Write(item)
+	}
 	sum := th.hasher.Sum(nil)
 	th.hasher.Reset()
 	return sum

--- a/treehasher.go
+++ b/treehasher.go
@@ -20,10 +20,8 @@ func newTreeHasher(hasher hash.Hash) *treeHasher {
 	return &th
 }
 
-func (th *treeHasher) digest(data ...[]byte) []byte {
-	for _, item := range data {
-		th.hasher.Write(item)
-	}
+func (th *treeHasher) digest(data []byte) []byte {
+	th.hasher.Write(data)
 	sum := th.hasher.Sum(nil)
 	th.hasher.Reset()
 	return sum

--- a/utils.go
+++ b/utils.go
@@ -49,3 +49,9 @@ func reverseByteSlices(sideNodes [][]byte) [][]byte {
 
 	return sideNodes
 }
+
+func valueKey(key, root []byte) []byte {
+	ret := make([]byte, len(root), len(root)+len(key))
+	copy(ret, root)
+	return append(ret, key...)
+}

--- a/utils.go
+++ b/utils.go
@@ -42,10 +42,10 @@ func emptyBytes(length int) []byte {
 	return b
 }
 
-func reverseByteSlices(sideNodes [][]byte) [][]byte {
-	for left, right := 0, len(sideNodes)-1; left < right; left, right = left+1, right-1 {
-		sideNodes[left], sideNodes[right] = sideNodes[right], sideNodes[left]
+func reverseByteSlices(slices [][]byte) [][]byte {
+	for left, right := 0, len(slices)-1; left < right; left, right = left+1, right-1 {
+		slices[left], slices[right] = slices[right], slices[left]
 	}
 
-	return sideNodes
+	return slices
 }

--- a/utils.go
+++ b/utils.go
@@ -42,7 +42,7 @@ func emptyBytes(length int) []byte {
 	return b
 }
 
-func reverseSideNodes(sideNodes [][]byte) [][]byte {
+func reverseByteSlices(sideNodes [][]byte) [][]byte {
 	for left, right := 0, len(sideNodes)-1; left < right; left, right = left+1, right-1 {
 		sideNodes[left], sideNodes[right] = sideNodes[right], sideNodes[left]
 	}

--- a/utils.go
+++ b/utils.go
@@ -49,9 +49,3 @@ func reverseByteSlices(sideNodes [][]byte) [][]byte {
 
 	return sideNodes
 }
-
-func valueKey(key, root []byte) []byte {
-	ret := make([]byte, len(root), len(root)+len(key))
-	copy(ret, root)
-	return append(ret, key...)
-}


### PR DESCRIPTION
Refactors the storage of values into a separate KV store, indexed by `hash(value)+key`. As noted in #14 loses the benefit of deduplication, while enabling pruning of records.

Completes work from https://github.com/celestiaorg/smt/pull/24.
Revises work from https://github.com/celestiaorg/smt/pull/36.