### PR TITLE
Fetch values immediately, updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ import(
 
 func main() {
     // Initialise two new key-value store to store the nodes and values of the tree
-    nodestore := smt.NewSimpleMap()
-    valuestore := smt.NewSimpleMap()
+    nodeStore := smt.NewSimpleMap()
+    valueStore := smt.NewSimpleMap()
     // Initialise the tree
-    tree := smt.NewSparseMerkleTree(nodestore, valuestore, sha256.New())
+    tree := smt.NewSparseMerkleTree(nodeStore, valueStore, sha256.New())
 
     // Update the key "foo" with the value "bar"
     tree.Update([]byte("foo"), []byte("bar"))

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 A Go library that implements a Sparse Merkle tree for a key-value map. The tree implements the same optimisations specified in the [Libra whitepaper](https://developers.libra.org/docs/assets/papers/the-libra-blockchain/2020-05-26.pdf), to reduce the number of hash operations required per tree operation to O(k) where k is the number of non-empty elements in the tree.
 
-[![Tests](https://github.com/lazyledger/smt/actions/workflows/test.yml/badge.svg)](https://github.com/lazyledger/smt/actions/workflows/test.yml)
-[![Coverage Status](https://coveralls.io/repos/github/lazyledger/smt/badge.svg?branch=master)](https://coveralls.io/github/lazyledger/smt?branch=master)
-[![GoDoc](https://godoc.org/github.com/lazyledger/smt?status.svg)](https://godoc.org/github.com/lazyledger/smt)
+[![Tests](https://github.com/celestiaorg/smt/actions/workflows/test.yml/badge.svg)](https://github.com/celestiaorg/smt/actions/workflows/test.yml)
+[![Coverage Status](https://coveralls.io/repos/github/celestiaorg/smt/badge.svg?branch=master)](https://coveralls.io/github/celestiaorg/smt?branch=master)
+[![GoDoc](https://godoc.org/github.com/celestiaorg/smt?status.svg)](https://godoc.org/github.com/celestiaorg/smt)
 
 ## Example
 
@@ -14,7 +14,7 @@ package main
 import(
     "fmt"
     "crypto/sha256"
-    "github.com/lazyledger/smt"
+    "github.com/celestiaorg/smt"
 )
 
 func main() {

--- a/README.md
+++ b/README.md
@@ -42,5 +42,4 @@ func main() {
 
 ## Future wishlist
 
-- **Garbage collection for obsolete nodes.** When tree is updated, obsolete nodes are not garbage collected, and so storage growth is unbounded. This is desirable for accessing previous revisions of the tree (for example, if you need to revert to a previous block in a blockchain due to a chain reorganisation caused by the chain's consensus algorithm), but otherwise undesirable for storage size. A future wishlist item is to extend the library to allow for an optional garbage collected version of the tree, though this requires further research.
 - **Tree sharding to process updates in parallel.** At the moment, the tree can only safely handle one update at a time. It would be desirable to shard the tree into multiple subtrees and allow parallel updates to the subtrees.

--- a/README.md
+++ b/README.md
@@ -18,10 +18,11 @@ import(
 )
 
 func main() {
-    // Initialise a new key-value store to store the nodes of the tree
-    store := smt.NewSimpleMap()
+    // Initialise two new key-value store to store the nodes and values of the tree
+    nodestore := smt.NewSimpleMap()
+    valuestore := smt.NewSimpleMap()
     // Initialise the tree
-    tree := smt.NewSparseMerkleTree(store, sha256.New())
+    tree := smt.NewSparseMerkleTree(nodestore, valuestore, sha256.New())
 
     // Update the key "foo" with the value "bar"
     tree.Update([]byte("foo"), []byte("bar"))

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 A Go library that implements a Sparse Merkle tree for a key-value map. The tree implements the same optimisations specified in the [Libra whitepaper](https://developers.libra.org/docs/assets/papers/the-libra-blockchain/2020-05-26.pdf), to reduce the number of hash operations required per tree operation to O(k) where k is the number of non-empty elements in the tree.
 
 [![Tests](https://github.com/celestiaorg/smt/actions/workflows/test.yml/badge.svg)](https://github.com/celestiaorg/smt/actions/workflows/test.yml)
-[![Coverage Status](https://coveralls.io/repos/github/celestiaorg/smt/badge.svg?branch=master)](https://coveralls.io/github/celestiaorg/smt?branch=master)
-[![GoDoc](https://godoc.org/github.com/celestiaorg/smt?status.svg)](https://godoc.org/github.com/celestiaorg/smt)
+[![Coverage Status](https://coveralls.io/repos/github/lazyledger/smt/badge.svg?branch=master)](https://coveralls.io/github/lazyledger/smt?branch=master)
+[![GoDoc](https://godoc.org/github.com/lazyledger/smt?status.svg)](https://godoc.org/github.com/lazyledger/smt)
 
 ## Example
 

--- a/deepsubtree_test.go
+++ b/deepsubtree_test.go
@@ -44,7 +44,21 @@ func TestDeepSparseMerkleSubTreeBasic(t *testing.T) {
 	if !bytes.Equal(value, []byte("testValue1")) {
 		t.Error("did not get correct value in deep subtree")
 	}
+	value, err = dsmst.GetDescend([]byte("testKey1"))
+	if err != nil {
+		t.Errorf("returned error when getting value in deep subtree: %v", err)
+	}
+	if !bytes.Equal(value, []byte("testValue1")) {
+		t.Error("did not get correct value in deep subtree")
+	}
 	value, err = dsmst.Get([]byte("testKey2"))
+	if err != nil {
+		t.Errorf("returned error when getting value in deep subtree: %v", err)
+	}
+	if !bytes.Equal(value, []byte("testValue2")) {
+		t.Error("did not get correct value in deep subtree")
+	}
+	value, err = dsmst.GetDescend([]byte("testKey2"))
 	if err != nil {
 		t.Errorf("returned error when getting value in deep subtree: %v", err)
 	}
@@ -58,7 +72,14 @@ func TestDeepSparseMerkleSubTreeBasic(t *testing.T) {
 	if !bytes.Equal(value, defaultValue) {
 		t.Error("did not get correct value in deep subtree")
 	}
-	value, err = dsmst.Get([]byte("testKey6"))
+	value, err = dsmst.GetDescend([]byte("testKey5"))
+	if err != nil {
+		t.Errorf("returned error when getting value in deep subtree: %v", err)
+	}
+	if !bytes.Equal(value, defaultValue) {
+		t.Error("did not get correct value in deep subtree")
+	}
+	_, err = dsmst.GetDescend([]byte("testKey6"))
 	if err == nil {
 		t.Error("did not error when getting non-added value in deep subtree")
 	}

--- a/smt.go
+++ b/smt.go
@@ -76,8 +76,17 @@ func (smt *SparseMerkleTree) Get(key []byte) ([]byte, error) {
 
 	path := smt.th.path(key)
 	value, err := smt.values.Get(path)
+
 	if err != nil {
-		return defaultValue, nil
+		var invalidKeyError *InvalidKeyError
+
+		if errors.As(err, &invalidKeyError) {
+			// If key isn't found, return default value
+			return defaultValue, nil
+		} else {
+			// Otherwise percolate up any other error
+			return nil, err
+		}
 	}
 	return value, nil
 }

--- a/smt.go
+++ b/smt.go
@@ -64,14 +64,11 @@ func (smt *SparseMerkleTree) depth() int {
 	return smt.th.pathSize() * 8
 }
 
-// Get gets a key from the tree.
+// Get gets the value of a key from the tree.
 func (smt *SparseMerkleTree) Get(key []byte) ([]byte, error) {
-	value, err := smt.GetForRoot(key, smt.Root())
-	return value, err
-}
+	// Get tree's root
+	root := smt.Root()
 
-// GetForRoot gets a key from the tree at a specific root.
-func (smt *SparseMerkleTree) GetForRoot(key []byte, root []byte) ([]byte, error) {
 	if bytes.Equal(root, smt.th.placeholder()) {
 		// The tree is empty, return the default value.
 		return defaultValue, nil
@@ -121,15 +118,10 @@ func (smt *SparseMerkleTree) GetForRoot(key []byte, root []byte) ([]byte, error)
 	return value, nil
 }
 
-// Has returns true if tree contains given key, false otherwise.
+// Has returns true if the value at the given key is non-default, false
+// otherwise.
 func (smt *SparseMerkleTree) Has(key []byte) (bool, error) {
 	val, err := smt.Get(key)
-	return !bytes.Equal(defaultValue, val), err
-}
-
-// HasForRoot returns true if tree contains given key at a specific root, false otherwise.
-func (smt *SparseMerkleTree) HasForRoot(key, root []byte) (bool, error) {
-	val, err := smt.GetForRoot(key, root)
 	return !bytes.Equal(defaultValue, val), err
 }
 

--- a/smt.go
+++ b/smt.go
@@ -75,45 +75,9 @@ func (smt *SparseMerkleTree) Get(key []byte) ([]byte, error) {
 	}
 
 	path := smt.th.path(key)
-	currentHash := root
-	for i := 0; i < smt.depth(); i++ {
-		currentData, err := smt.nodes.Get(currentHash)
-		if err != nil {
-			return nil, err
-		} else if smt.th.isLeaf(currentData) {
-			// We've reached the end. Is this the actual leaf?
-			p, _ := smt.th.parseLeaf(currentData)
-			if !bytes.Equal(path, p) {
-				// Nope. Therefore the key is actually empty.
-				return defaultValue, nil
-			}
-			// Otherwise, yes. Return the value.
-			value, err := smt.values.Get(path)
-			if err != nil {
-				return nil, err
-			}
-			return value, nil
-		}
-
-		leftNode, rightNode := smt.th.parseNode(currentData)
-		if getBitAtFromMSB(path, i) == right {
-			currentHash = rightNode
-		} else {
-			currentHash = leftNode
-		}
-
-		if bytes.Equal(currentHash, smt.th.placeholder()) {
-			// We've hit a placeholder value; this is the end.
-			return defaultValue, nil
-		}
-	}
-
-	// The following lines of code should only be reached if the path is 256
-	// nodes high, which should be very unlikely if the underlying hash function
-	// is collision-resistant.
 	value, err := smt.values.Get(path)
 	if err != nil {
-		return nil, err
+		return defaultValue, nil
 	}
 	return value, nil
 }


### PR DESCRIPTION
Make updates as per https://github.com/celestiaorg/smt/pull/37#issuecomment-876416919.

Fixes #8 #14.

1. Clean up readme.
1. Remove `Get/HasForRoot`.
1. Fetch values immediately instead of descending the tree.
1. Add new methods to descend the tree for DSMST since key might not have been added with `AddBranch`.