### PR TITLE
fuzz: add .Delete fuzzing

### DIFF
--- a/fuzz/delete/fuzz.go
+++ b/fuzz/delete/fuzz.go
@@ -1,0 +1,37 @@
+package delete
+
+import (
+	"bytes"
+	"crypto/sha256"
+
+	"github.com/celestiaorg/smt"
+)
+
+func Fuzz(data []byte) int {
+	if len(data) == 0 {
+		return -1
+	}
+
+	splits := bytes.Split(data, []byte("*"))
+	if len(splits) < 3 {
+		return -1
+	}
+
+	smn, smv := smt.NewSimpleMap(), smt.NewSimpleMap()
+	tree := smt.NewSparseMerkleTree(smn, smv, sha256.New())
+	for i := 0; i < len(splits)-1; i += 2 {
+		key, value := splits[i], splits[i+1]
+		tree.Update(key, value)
+	}
+
+	deleteKey := splits[len(splits)-1]
+	newRoot, err := tree.Delete(deleteKey)
+
+	if err != nil {
+		return 0
+	}
+	if len(newRoot) == 0 {
+		panic("newRoot is nil yet err==nil")
+	}
+	return 1
+}

--- a/fuzz/delete/fuzz.go
+++ b/fuzz/delete/fuzz.go
@@ -26,7 +26,6 @@ func Fuzz(data []byte) int {
 
 	deleteKey := splits[len(splits)-1]
 	newRoot, err := tree.Delete(deleteKey)
-
 	if err != nil {
 		return 0
 	}

--- a/oss-fuzz-build.sh
+++ b/oss-fuzz-build.sh
@@ -3,3 +3,4 @@
 export FUZZ_ROOT="github.com/celestiaorg/smt"
 
 compile_go_fuzzer "$FUZZ_ROOT"/fuzz Fuzz fuzz_basic_op fuzz
+compile_go_fuzzer "$FUZZ_ROOT"/fuzz/delete Fuzz fuzz_delete fuzz


### PR DESCRIPTION
Adds an oss-fuzz pass for fuzzing just .Delete in which a tree is populated by corpus generated by <KEY>*<VALUE>[...]<DELETE_KEY>

/cc @cuonglm 