### PR TITLE
Expose leaf node with smt.GetLeaf()

### DIFF
--- a/smt_test.go
+++ b/smt_test.go
@@ -630,8 +630,11 @@ func TestGetLeaf(t *testing.T) {
 		if err != nil {
 			t.Errorf("returned error when getting empty key: %v", err)
 		}
-		if leaf != nil {
-			t.Error("did not get nil when getting empty key")
+		if leaf.ValueHash != nil {
+			t.Error("did not get nil ValueHash when getting empty key")
+		}
+		if leaf.Path == nil {
+			t.Error("got nil Path when getting empty key")
 		}
 
 		_, err = smt.Update([]byte("testKey"), []byte("testValue"))


### PR DESCRIPTION
This will allow access to the contents of a leaf node, including the node path and hashed value.

This will support an [update to Cosmos SDK ADR-040](https://github.com/cosmos/cosmos-sdk/pull/9680) by allowing access to the hashed value and path without any redundant hashing.

Note: should we optimize this to allow fetching the leaf node directly rather than descending the tree, as has been done for value lookup?