### PR TITLE
fuzz: return nil if len(keys) is zero

### DIFF
--- a/fuzz/fuzz.go
+++ b/fuzz/fuzz.go
@@ -24,6 +24,9 @@ func Fuzz(input []byte) int {
 			keys = append(keys, k)
 			return k
 		}
+		if len(keys) == 0 {
+			return nil
+		}
 		return keys[int(readByte(r))%len(keys)]
 	}
 	for i := 0; r.Len() != 0; i++ {


### PR DESCRIPTION
Fixes a divide by zero exception which resulted
from a modulo operation using keys that were non-existent.
oss-fuzz reported a crash

    https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=37182

but that was a fault in the fuzzing code, and not in smt.