### PR TITLE
Minor improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,32 +11,33 @@ A Go library that implements a Sparse Merkle tree for a key-value map. The tree 
 ```go
 package main
 
-import(
-    "fmt"
-    "crypto/sha256"
-    "github.com/celestiaorg/smt"
+import (
+	"crypto/sha256"
+	"fmt"
+
+	"github.com/celestiaorg/smt"
 )
 
 func main() {
-    // Initialise two new key-value store to store the nodes and values of the tree
-    nodeStore := smt.NewSimpleMap()
-    valueStore := smt.NewSimpleMap()
-    // Initialise the tree
-    tree := smt.NewSparseMerkleTree(nodeStore, valueStore, sha256.New())
+	// Initialise two new key-value store to store the nodes and values of the tree
+	nodeStore := smt.NewSimpleMap()
+	valueStore := smt.NewSimpleMap()
+	// Initialise the tree
+	tree := smt.NewSparseMerkleTree(nodeStore, valueStore, sha256.New())
 
-    // Update the key "foo" with the value "bar"
-    tree.Update([]byte("foo"), []byte("bar"))
+	// Update the key "foo" with the value "bar"
+	_, _ = tree.Update([]byte("foo"), []byte("bar"))
 
-    // Generate a Merkle proof for foo=bar
-    proof, _ := tree.Prove([]byte("foo"))
-    root := tree.Root() // We also need the current tree root for the proof
+	// Generate a Merkle proof for foo=bar
+	proof, _ := tree.Prove([]byte("foo"))
+	root := tree.Root() // We also need the current tree root for the proof
 
-    // Verify the Merkle proof for foo=bar
-    if smt.VerifyProof(proof, root, []byte("foo"), []byte("bar"), sha256.New()) {
-        fmt.Println("Proof verification succeeded.")
-    } else {
-        fmt.Println("Proof verification failed.")
-    }
+	// Verify the Merkle proof for foo=bar
+	if smt.VerifyProof(proof, root, []byte("foo"), []byte("bar"), sha256.New()) {
+		fmt.Println("Proof verification succeeded.")
+	} else {
+		fmt.Println("Proof verification failed.")
+	}
 }
 ```
 

--- a/smt.go
+++ b/smt.go
@@ -135,7 +135,7 @@ func (smt *SparseMerkleTree) UpdateForRoot(key []byte, value []byte, root []byte
 
 	} else {
 		// Insert or update operation.
-		newRoot, err = smt.updateWithSideNodes(key, path, value, sideNodes, pathNodes, oldLeafData)
+		newRoot, err = smt.updateWithSideNodes(path, value, sideNodes, pathNodes, oldLeafData)
 	}
 	return newRoot, err
 }
@@ -211,7 +211,7 @@ func (smt *SparseMerkleTree) deleteWithSideNodes(path []byte, sideNodes [][]byte
 	return currentHash, nil
 }
 
-func (smt *SparseMerkleTree) updateWithSideNodes(key, path []byte, value []byte, sideNodes [][]byte, pathNodes [][]byte, oldLeafData []byte) ([]byte, error) {
+func (smt *SparseMerkleTree) updateWithSideNodes(path []byte, value []byte, sideNodes [][]byte, pathNodes [][]byte, oldLeafData []byte) ([]byte, error) {
 	valueHash := smt.th.digest(value)
 	currentHash, currentData := smt.th.digestLeaf(path, valueHash)
 	if err := smt.nodes.Set(currentHash, currentData); err != nil {

--- a/utils.go
+++ b/utils.go
@@ -11,7 +11,7 @@ func getBitAtFromMSB(data []byte, position int) int {
 // setBitAtFromMSB sets the bit at an offset from the most significant bit
 func setBitAtFromMSB(data []byte, position int) {
 	n := int(data[position/8])
-	n |= (1 << (8 - 1 - uint(position)%8))
+	n |= 1 << (8 - 1 - uint(position)%8)
 	data[position/8] = byte(n)
 }
 


### PR DESCRIPTION
- remove obsolete key param in `updateWithSideNodes` introduced in #37 and only removed on deletes https://github.com/celestiaorg/smt/pull/37/commits/a207801d6e4c47e5e790be0ddf876c1e7a571793
- remove redundant parentheses
- properly format example code and make explicit that Update returns two params

As a nice side effect this will trigger having a baseline on master for future benchmark runs of bencher.